### PR TITLE
Ignored NPM debug log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-#Node Modules
+#NPM Files
 node_modules/
+./npm-debug.log
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-
 *.iml
 
 ## Directory-based project format:


### PR DESCRIPTION
Added the npm-debug.log file to the .gitignore file to remove it from source control
